### PR TITLE
Add usage of GitRequest instead of HTTP adress to Integration. Fix #22

### DIFF
--- a/src/main/java/com/group21/continous_integration/ContinuousIntegrationServer.java
+++ b/src/main/java/com/group21/continous_integration/ContinuousIntegrationServer.java
@@ -27,12 +27,12 @@ public class ContinuousIntegrationServer extends AbstractHandler
 
         System.out.println("* Handling request: " + target);
 
-
+        GitRequest req = null;
         if(request.getMethod().equals("POST")){
             
             String payload = IOUtils.toString(request.getReader());
             
-            GitRequest req = new GitRequest(payload); 
+            req = new GitRequest(payload); 
             /* //PRINTS FOR TESTING
             System.out.println(req.email_addr);
             System.out.println(req.commit_hash);
@@ -46,7 +46,7 @@ public class ContinuousIntegrationServer extends AbstractHandler
         }
 
         if(target.equalsIgnoreCase("/")){
-            Integration integ = new Integration("https://github.com/perfah/CONTINOUS_INTEGRATION.git", "master");
+            Integration integ = new Integration("https://github.com/perfah/CONTINOUS_INTEGRATION.git", req);
             
             BuildResult compilation = integ.build();
             BuildHistory.getInstance().insert(compilation);

--- a/src/main/java/com/group21/continous_integration/ContinuousIntegrationServer.java
+++ b/src/main/java/com/group21/continous_integration/ContinuousIntegrationServer.java
@@ -46,7 +46,7 @@ public class ContinuousIntegrationServer extends AbstractHandler
         }
 
         if(target.equalsIgnoreCase("/")){
-            Integration integ = new Integration("https://github.com/perfah/CONTINOUS_INTEGRATION.git", req);
+            Integration integ = new Integration(req);
             
             BuildResult compilation = integ.build();
             BuildHistory.getInstance().insert(compilation);

--- a/src/main/java/com/group21/continous_integration/Integration.java
+++ b/src/main/java/com/group21/continous_integration/Integration.java
@@ -14,15 +14,16 @@ public class Integration
 {
     private String repoName;
     private String branch;
-    private Git repository = null;
+    private GitRequest req;
     private InvocationRequest request;
     private Invoker invoker;
     private BuildResult lastBuildResult;
 
-    public Integration(String cloneURL, String branch)
+    public Integration(String cloneURL, GitRequest req)
     {
-        repoName = cloneURL.substring(cloneURL.lastIndexOf("/") + 1, cloneURL.length()).replace(".git", "");
-        this.branch = branch;
+        this.req = req;
+        repoName = req.repository;
+        branch = req.branch;
 
         Path integrationsDir = new File("").toPath().resolve("integrations");
         Path repoDir = integrationsDir.resolve(repoName);
@@ -77,7 +78,7 @@ public class Integration
             result = invoker.execute(request);
             lastBuildResult.repository = repoName;
             lastBuildResult.branch = branch;
-            lastBuildResult.linkedCommit = "TODO";
+            lastBuildResult.linkedCommit = req.commit_hash;
             lastBuildResult.status = result.getExitCode() == 0;
             lastBuildResult.message = result.getExecutionException() != null ? result.getExecutionException().getMessage() : null;
             

--- a/src/main/java/com/group21/continous_integration/Integration.java
+++ b/src/main/java/com/group21/continous_integration/Integration.java
@@ -14,16 +14,19 @@ public class Integration
 {
     private String repoName;
     private String branch;
+    private String URL;
+    private Git repository;
     private GitRequest req;
     private InvocationRequest request;
     private Invoker invoker;
     private BuildResult lastBuildResult;
 
-    public Integration(String cloneURL, GitRequest req)
+    public Integration(GitRequest req)
     {
         this.req = req;
         repoName = req.repository;
         branch = req.branch;
+        URL = req.cloneUrl;
 
         Path integrationsDir = new File("").toPath().resolve("integrations");
         Path repoDir = integrationsDir.resolve(repoName);
@@ -42,7 +45,7 @@ public class Integration
 
         try{
             repository = Git.cloneRepository()
-                .setURI(cloneURL)
+                .setURI(URL)
                 .setBranch(branch)
                 .setDirectory(branchDir)
                 .call();


### PR DESCRIPTION
Adds

- commit hash information to build

- changes to use gitrequest structure instead of pulling info from http url